### PR TITLE
Implement add label

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ LOG_LEVEL=debug
 
 # Go to https://smee.io/new set this to the URL that you are redirected to.
 WEBHOOK_PROXY_URL=
+
+# For example, when competing with dokcer
+# PORT=4567

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,28 +20,6 @@ const PROJECT_FRAGMENT = `
   }
 `;
 
-// const getCardAndColumnAutomationCards = `
-//   query getCardAndColumnAutomationCards($issueUrl: URI!) {
-//     resource(url: $issueUrl) {
-//       ... on Issue {
-//         projectCards(first: 10) {
-//           nodes {
-//             id
-//             url
-//             column {
-//               name
-//               id
-//             }
-//             project {
-//               ${PROJECT_FRAGMENT}
-//             }
-//           }
-//         }
-//       }
-//     }
-//   }
-// `;
-
 const getAllProjectCards = `
   query getAllProjectCards($id: ID!) {
     node(id: $id) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,43 @@ const addComment = `
   }
 `;
 
+const projectCards = `
+query getCardAndColumnAutomationCards($issueUrl: URI!) {
+  resource(url: $issueUrl) {
+    ... on Issue {
+      projectCards(first: 100) {
+        nodes {
+          id
+          url
+          column {
+            name
+            id
+          }
+        }
+      }
+    }
+  }
+}
+`;
+
 export = (app: Application) => {
+  const logger = app.log.child({ name: "projectabot" });
   app.on("issues.labeled", async (context) => {
-    console.log("labeled!!!", context);
+    logger.info("labeled!!!", context);
+    const issueUrl = context.payload.issue.html_url;
     context.github.graphql(addComment, {
       id: context.payload.issue.node_id,
       body: "Hello world!",
     });
+
+    const { resource }: any = await context.github.graphql(projectCards, {
+      issueUrl: issueUrl,
+    });
+
+    logger.info("resource!!!", resource);
+    const cardsForIssue = resource.projectCards.nodes;
+    for (const issueCard of cardsForIssue) {
+      logger.info("issueCard!!!", issueCard);
+    }
   });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ const PROJECT_FRAGMENT = `
   }
 `;
 
+// FIXME: getAllProjectColumns かもしれない
 const getAllProjectCards = `
   query getAllProjectCards($id: ID!) {
     node(id: $id) {
@@ -59,9 +60,12 @@ export = (app: Application) => {
     });
 
     logger.info("node!!!", node);
-    // TODO: Organization の時は node.owner.projects.nodes にする
-    const projects = node.projects.nodes;
+    // Organization の時は node.owner.projects.nodes にする
+    // NOTE: getAllProjectCards の query で ... on Organization で owner の projects を取得しているため、
+    //   User の時は node.owner.projects がない
+    const projects = node.owner.projects?.nodes || node.projects.nodes;
     const columns: any = [];
+    // User の時も対象の repository が複数の projects を持つ場合あり
     projects.forEach((pj: any) => {
       logger.info("project!!!", pj);
       pj.columns.nodes.forEach((col: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,74 @@
 import { Application } from "probot"; // eslint-disable-line no-unused-vars
 
-const addComment = `
-  mutation comment($id: ID!, $body: String!) {
-    addComment(input: {subjectId: $id, body: $body}) {
-      clientMutationId
+const PROJECT_FRAGMENT = `
+  name
+  id
+  columns(first: 50) {
+    totalCount
+    nodes {
+      id
+      url
+      lastCards: cards(last: 1, archivedStates: NOT_ARCHIVED) {
+        totalCount
+        nodes {
+          url
+          id
+          note
+        }
+      }
     }
   }
 `;
 
-const projectCards = `
-query getCardAndColumnAutomationCards($issueUrl: URI!) {
-  resource(url: $issueUrl) {
-    ... on Issue {
-      projectCards(first: 100) {
-        nodes {
-          id
-          url
-          column {
-            name
-            id
+// const getCardAndColumnAutomationCards = `
+//   query getCardAndColumnAutomationCards($issueUrl: URI!) {
+//     resource(url: $issueUrl) {
+//       ... on Issue {
+//         projectCards(first: 10) {
+//           nodes {
+//             id
+//             url
+//             column {
+//               name
+//               id
+//             }
+//             project {
+//               ${PROJECT_FRAGMENT}
+//             }
+//           }
+//         }
+//       }
+//     }
+//   }
+// `;
+
+const getAllProjectCards = `
+  query getAllProjectCards($issueUrl: URI!) {
+    resource(url: $issueUrl) {
+      ... on Issue {
+        id
+        repository {
+          owner {
+            url
+            ${"" /* Projects can be attached to an Organization... */}
+            ... on Organization {
+              projects(first: 10, states: [OPEN]) {
+                nodes {
+                  ${PROJECT_FRAGMENT}
+                }
+              }
+            }
+          }
+          ${"" /* ... or on a Repository */}
+          projects(first: 10, states: [OPEN]) {
+            nodes {
+              ${PROJECT_FRAGMENT}
+            }
           }
         }
       }
     }
   }
-}
 `;
 
 export = (app: Application) => {
@@ -32,19 +76,33 @@ export = (app: Application) => {
   app.on("issues.labeled", async (context) => {
     logger.info("labeled!!!", context);
     const issueUrl = context.payload.issue.html_url;
-    context.github.graphql(addComment, {
-      id: context.payload.issue.node_id,
-      body: "Hello world!",
-    });
-
-    const { resource }: any = await context.github.graphql(projectCards, {
+    const issueId = context.payload.issue.node_id;
+    const { resource }: any = await context.github.graphql(getAllProjectCards, {
       issueUrl: issueUrl,
     });
 
     logger.info("resource!!!", resource);
-    const cardsForIssue = resource.projectCards.nodes;
-    for (const issueCard of cardsForIssue) {
-      logger.info("issueCard!!!", issueCard);
-    }
+    const projects = resource.repository.projects.nodes;
+    const columns: any = [];
+    projects.forEach((pj: any) => {
+      logger.info("project!!!", pj);
+      pj.columns.nodes.forEach((col: any) => {
+        logger.info("column!!!", col);
+        columns.push(col);
+      });
+    });
+    logger.info("multiple columns!!!", columns);
+
+    // すでに追加済みの時は Project already has the associated issue のエラーが出る
+    await context.github.graphql(
+      `
+      mutation createCard($contentId: ID!, $columnId: ID!) {
+        addProjectCard(input: {contentId: $contentId, projectColumnId: $columnId}) {
+          clientMutationId
+        }
+      }
+    `,
+      { contentId: issueId, columnId: columns[0].id }
+    );
   });
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,19 @@
 import { Application } from "probot"; // eslint-disable-line no-unused-vars
 
-export = (app: Application) => {
-  app.on("issues.opened", async (context) => {
-    const issueComment = context.issue({
-      body: "Thanks for opening this issue!",
-    });
-    await context.github.issues.createComment(issueComment);
-  });
-  // For more information on building apps:
-  // https://probot.github.io/docs/
+const addComment = `
+  mutation comment($id: ID!, $body: String!) {
+    addComment(input: {subjectId: $id, body: $body}) {
+      clientMutationId
+    }
+  }
+`;
 
-  // To get your app running against GitHub, see:
-  // https://probot.github.io/docs/development/
+export = (app: Application) => {
+  app.on("issues.labeled", async (context) => {
+    console.log("labeled!!!", context);
+    context.github.graphql(addComment, {
+      id: context.payload.issue.node_id,
+      body: "Hello world!",
+    });
+  });
 };


### PR DESCRIPTION
## Overview

See. #1 

Webhook イベント（ラベル追加）が起きた該当 repository の project の columns を取得して最初のカラムに当該 issue をカードとして追加するするようにした。

## 残りやること

- [x] PR にも対応
- [x] Organization に対応（動作は未確認）
- Automation Rules カードをパースできるようにする
- カードがすでに作成されていた場合の例外処理

## Note

- repository に生えてる projects と repository の owner に生えてる projects は違う？
    - project-bot では Organization の時は repository の owner に生えてる projects、User の時は repository に生えてる projects を使ってた
    - **結論: User の owner に生えてる projects は https://github.com/daido1976?tab=projects のところにあるユーザに紐づく projects になってしまうのでリポジトリのやつとは全然違うリソースになってしまう**
- webhook の `context.payload` に issue or pr の情報が入ってるので、カード追加時に必要な issue or pr の id には `context.payload.{issue | pr}.node_id` を使う
- webhook の `context.payload` に repository の情報も入っているので、project の取得には repository の `node_id` を使う
- 元ネタのコードでは [issue_url から辿る複雑なやり方](https://github.com/philschatz/project-bot/blob/d6dc0826c1e6b32278464d9eed006488eae522cb/src/index.js#L62) だったが 👆 の方がすっきり書ける