### PR TITLE
Parse automation rules card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1192,6 +1192,12 @@
       "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
       "dev": true
     },
+    "@types/marked": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.7.4.tgz",
+      "integrity": "sha512-fdg0NO4qpuHWtZk6dASgsrBggY+8N4dWthl1bAQG9ceKUNKFjqpHaDKCAhRUI6y8vavG7hLSJ4YBwJtZyZEXqw==",
+      "dev": true
+    },
     "@types/nock": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@types/nock/-/nock-11.1.0.tgz",
@@ -6942,6 +6948,11 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.0.tgz",
+      "integrity": "sha512-EkE7RW6KcXfMHy2PA7Jg0YJE1l8UPEZE8k45tylzmZM30/r1M1MUXWQfJlrSbsTeh7m/XTwHbWUENvAJZpp1YA=="
     },
     "md5": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
     "test:watch": "jest --watch --notify --notifyMode=change --coverage"
   },
   "dependencies": {
+    "marked": "^1.1.0",
     "probot": "^9.5.3"
   },
   "devDependencies": {
     "@types/jest": "^25.1.0",
+    "@types/marked": "^0.7.4",
     "@types/nock": "^11.1.0",
     "@types/node": "^13.1.0",
     "@typescript-eslint/parser": "^2.4.0",

--- a/src/@types/marked/index.d.ts
+++ b/src/@types/marked/index.d.ts
@@ -1,3 +1,7 @@
+// Added Comments
+// See. https://github.com/markedjs/marked/issues/1675
+// See. https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/marked
+
 // Type definitions for Marked 0.7
 // Project: https://github.com/markedjs/marked, https://marked.js.org
 // Definitions by: William Orr <https://github.com/worr>
@@ -236,6 +240,7 @@ declare namespace marked {
     | Tokens.Hr
     | Tokens.BlockquoteStart
     | Tokens.BlockquoteEnd
+    | Tokens.List
     | Tokens.ListStart
     | Tokens.LooseItemStart
     | Tokens.ListItemStart
@@ -280,6 +285,11 @@ declare namespace marked {
 
     interface BlockquoteEnd {
       type: "blockquote_end";
+    }
+
+    interface List {
+      type: "list";
+      ordered: boolean;
     }
 
     interface ListStart {

--- a/src/@types/marked/index.d.ts
+++ b/src/@types/marked/index.d.ts
@@ -1,0 +1,414 @@
+// Type definitions for Marked 0.7
+// Project: https://github.com/markedjs/marked, https://marked.js.org
+// Definitions by: William Orr <https://github.com/worr>
+//                 BendingBender <https://github.com/BendingBender>
+//                 CrossR <https://github.com/CrossR>
+//                 Mike Wickett <https://github.com/mwickett>
+//                 Hitomi Hatsukaze <https://github.com/htkzhtm>
+//                 Ezra Celli <https://github.com/ezracelli>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export as namespace marked;
+
+export = marked;
+/**
+ * Compiles markdown to HTML synchronously.
+ *
+ * @param src String of markdown source to be compiled
+ * @param options Optional hash of options
+ * @return String of compiled HTML
+ */
+declare function marked(src: string, options?: marked.MarkedOptions): string;
+
+/**
+ * Compiles markdown to HTML asynchronously.
+ *
+ * @param src String of markdown source to be compiled
+ * @param callback Function called when the markdownString has been fully parsed when using async highlighting
+ */
+declare function marked(
+  src: string,
+  callback: (error: any | undefined, parseResult: string) => void
+): void;
+
+/**
+ * Compiles markdown to HTML asynchronously.
+ *
+ * @param src String of markdown source to be compiled
+ * @param options Hash of options
+ * @param callback Function called when the markdownString has been fully parsed when using async highlighting
+ */
+declare function marked(
+  src: string,
+  options: marked.MarkedOptions,
+  callback: (error: any | undefined, parseResult: string) => void
+): void;
+
+declare namespace marked {
+  const defaults: MarkedOptions;
+
+  /**
+   * @param src String of markdown source to be compiled
+   * @param options Hash of options
+   */
+  function lexer(src: string, options?: MarkedOptions): TokensList;
+
+  /**
+   * @param src String of markdown source to be compiled
+   * @param links Array of links
+   * @param options Hash of options
+   * @return String of compiled HTML
+   */
+
+  function inlineLexer(
+    src: string,
+    links: string[],
+    options?: MarkedOptions
+  ): string;
+
+  /**
+   * Compiles markdown to HTML.
+   *
+   * @param src String of markdown source to be compiled
+   * @param callback Function called when the markdownString has been fully parsed when using async highlighting
+   * @return String of compiled HTML
+   */
+  function parse(
+    src: string,
+    callback: (error: any | undefined, parseResult: string) => void
+  ): string;
+
+  /**
+   * Compiles markdown to HTML.
+   *
+   * @param src String of markdown source to be compiled
+   * @param options Hash of options
+   * @param callback Function called when the markdownString has been fully parsed when using async highlighting
+   * @return String of compiled HTML
+   */
+  function parse(
+    src: string,
+    options?: MarkedOptions,
+    callback?: (error: any | undefined, parseResult: string) => void
+  ): string;
+
+  /**
+   * @param src Tokenized source as array of tokens
+   * @param options Hash of options
+   */
+  function parser(src: TokensList, options?: MarkedOptions): string;
+
+  /**
+   * Sets the default options.
+   *
+   * @param options Hash of options
+   */
+  function options(options: MarkedOptions): typeof marked;
+
+  /**
+   * Sets the default options.
+   *
+   * @param options Hash of options
+   */
+  function setOptions(options: MarkedOptions): typeof marked;
+
+  /**
+   * Gets the original marked default options.
+   */
+  function getDefaults(): MarkedOptions;
+
+  class InlineLexer {
+    constructor(links: string[], options?: MarkedOptions);
+    options: MarkedOptions;
+    links: string[];
+    rules: Rules;
+    renderer: Renderer;
+    static rules: Rules;
+    static output(
+      src: string,
+      links: string[],
+      options?: MarkedOptions
+    ): string;
+    output(src: string): string;
+    static escapes(text: string): string;
+    outputLink(cap: string[], link: string): string;
+    smartypants(text: string): string;
+    mangle(text: string): string;
+  }
+
+  class Renderer {
+    constructor(options?: MarkedOptions);
+    options: MarkedOptions;
+    code(
+      code: string,
+      language: string | undefined,
+      isEscaped: boolean
+    ): string;
+    blockquote(quote: string): string;
+    html(html: string): string;
+    heading(
+      text: string,
+      level: 1 | 2 | 3 | 4 | 5 | 6,
+      raw: string,
+      slugger: Slugger
+    ): string;
+    hr(): string;
+    list(body: string, ordered: boolean, start: number): string;
+    listitem(text: string): string;
+    checkbox(checked: boolean): string;
+    paragraph(text: string): string;
+    table(header: string, body: string): string;
+    tablerow(content: string): string;
+    tablecell(
+      content: string,
+      flags: {
+        header: boolean;
+        align: "center" | "left" | "right" | null;
+      }
+    ): string;
+    strong(text: string): string;
+    em(text: string): string;
+    codespan(code: string): string;
+    br(): string;
+    del(text: string): string;
+    link(href: string | null, title: string | null, text: string): string;
+    image(href: string | null, title: string | null, text: string): string;
+    text(text: string): string;
+  }
+
+  class TextRenderer {
+    strong(text: string): string;
+    em(text: string): string;
+    codespan(text: string): string;
+    del(text: string): string;
+    text(text: string): string;
+    link(href: string | null, title: string | null, text: string): string;
+    image(href: string | null, title: string | null, text: string): string;
+    br(): string;
+  }
+
+  class Parser {
+    constructor(options?: MarkedOptions);
+    tokens: TokensList;
+    token: Token | null;
+    options: MarkedOptions;
+    renderer: Renderer;
+    slugger: Slugger;
+    static parse(src: TokensList, options?: MarkedOptions): string;
+    parse(src: TokensList): string;
+    next(): Token;
+    peek(): Token | 0;
+    parseText(): string;
+    tok(): string;
+  }
+
+  class Lexer {
+    constructor(options?: MarkedOptions);
+    tokens: TokensList;
+    options: MarkedOptions;
+    rules: Rules;
+    static rules: Rules;
+    static lex(src: TokensList, options?: MarkedOptions): TokensList;
+    lex(src: string): TokensList;
+    token(src: string, top: boolean): TokensList;
+  }
+
+  class Slugger {
+    seen: { [slugValue: string]: number };
+    slug(value: string): string;
+  }
+
+  interface Rules {
+    [ruleName: string]: RegExp | Rules;
+  }
+
+  type TokensList = Token[] & {
+    links: {
+      [key: string]: { href: string | null; title: string | null };
+    };
+  };
+
+  type Token =
+    | Tokens.Space
+    | Tokens.Code
+    | Tokens.Heading
+    | Tokens.Table
+    | Tokens.Hr
+    | Tokens.BlockquoteStart
+    | Tokens.BlockquoteEnd
+    | Tokens.ListStart
+    | Tokens.LooseItemStart
+    | Tokens.ListItemStart
+    | Tokens.ListItemEnd
+    | Tokens.ListEnd
+    | Tokens.Paragraph
+    | Tokens.HTML
+    | Tokens.Text;
+
+  namespace Tokens {
+    interface Space {
+      type: "space";
+    }
+
+    interface Code {
+      type: "code";
+      codeBlockStyle?: "indented";
+      lang?: string;
+      text: string;
+    }
+
+    interface Heading {
+      type: "heading";
+      depth: number;
+      text: string;
+    }
+
+    interface Table {
+      type: "table";
+      header: string[];
+      align: Array<"center" | "left" | "right" | null>;
+      cells: string[][];
+    }
+
+    interface Hr {
+      type: "hr";
+    }
+
+    interface BlockquoteStart {
+      type: "blockquote_start";
+    }
+
+    interface BlockquoteEnd {
+      type: "blockquote_end";
+    }
+
+    interface ListStart {
+      type: "list_start";
+      ordered: boolean;
+    }
+
+    interface LooseItemStart {
+      type: "loose_item_start";
+    }
+
+    interface ListItemStart {
+      type: "list_item_start";
+    }
+
+    interface ListItemEnd {
+      type: "list_item_end";
+    }
+
+    interface ListEnd {
+      type: "list_end";
+    }
+
+    interface Paragraph {
+      type: "paragraph";
+      pre?: boolean;
+      text: string;
+    }
+
+    interface HTML {
+      type: "html";
+      pre: boolean;
+      text: string;
+    }
+
+    interface Text {
+      type: "text";
+      text: string;
+    }
+  }
+
+  interface MarkedOptions {
+    /**
+     * A prefix URL for any relative link.
+     */
+    baseUrl?: string;
+
+    /**
+     * Enable GFM line breaks. This option requires the gfm option to be true.
+     */
+    breaks?: boolean;
+
+    /**
+     * Enable GitHub flavored markdown.
+     */
+    gfm?: boolean;
+
+    /**
+     * Include an id attribute when emitting headings.
+     */
+    headerIds?: boolean;
+
+    /**
+     * Set the prefix for header tag ids.
+     */
+    headerPrefix?: string;
+
+    /**
+     * A function to highlight code blocks. The function can either be
+     * synchronous (returning a string) or asynchronous (callback invoked
+     * with an error if any occurred during highlighting and a string
+     * if highlighting was successful)
+     */
+    highlight?(
+      code: string,
+      lang: string,
+      callback?: (error: any | undefined, code?: string) => void
+    ): string | void;
+
+    /**
+     * Set the prefix for code block classes.
+     */
+    langPrefix?: string;
+
+    /**
+     * Mangle autolinks (<email@domain.com>).
+     */
+    mangle?: boolean;
+
+    /**
+     * Conform to obscure parts of markdown.pl as much as possible. Don't fix any of the original markdown bugs or poor behavior.
+     */
+    pedantic?: boolean;
+
+    /**
+     * Type: object Default: new Renderer()
+     *
+     * An object containing functions to render tokens to HTML.
+     */
+    renderer?: Renderer;
+
+    /**
+     * Sanitize the output. Ignore any HTML that has been input.
+     */
+    sanitize?: boolean;
+
+    /**
+     * Optionally sanitize found HTML with a sanitizer function.
+     */
+    sanitizer?(html: string): string;
+
+    /**
+     * Shows an HTML error message when rendering fails.
+     */
+    silent?: boolean;
+
+    /**
+     * Use smarter list behavior than the original markdown. May eventually be default with the old behavior moved into pedantic.
+     */
+    smartLists?: boolean;
+
+    /**
+     * Use "smart" typograhic punctuation for things like quotes and dashes.
+     */
+    smartypants?: boolean;
+
+    /**
+     * Generate closing slash for self-closing tags (<br/> instead of <br>)
+     */
+    xhtml?: boolean;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ export = (app: Application) => {
       project.columns.nodes.forEach((column: any) => {
         logger.info("column!!!", column);
         const lastCard = column.lastCards.nodes[0];
+        logger.info("lastCard!!!", lastCard);
         columns.push({
           column,
           // TODO: lastCard を parse して ruleName (eg. 'added_label', 'new_issue' ) と ruleArgs (eg. ['dependencies', 'bug']) を抜き出す

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,11 +66,17 @@ export = (app: Application) => {
     const projects = node.owner.projects?.nodes || node.projects.nodes;
     const columns: any = [];
     // User の時も対象の repository が複数の projects を持つ場合あり
-    projects.forEach((pj: any) => {
-      logger.info("project!!!", pj);
-      pj.columns.nodes.forEach((col: any) => {
-        logger.info("column!!!", col);
-        columns.push(col);
+    projects.forEach((project: any) => {
+      logger.info("project!!!", project);
+      project.columns.nodes.forEach((column: any) => {
+        logger.info("column!!!", column);
+        const lastCard = column.lastCards.nodes[0];
+        columns.push({
+          column,
+          // TODO: lastCard を parse して ruleName (eg. 'added_label', 'new_issue' ) と ruleArgs (eg. ['dependencies', 'bug']) を抜き出す
+          ruleName: "",
+          ruleArgs: [],
+        });
       });
     });
     logger.info("multiple columns!!!", columns);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,24 @@
-import { Application } from "probot"; // eslint-disable-line no-unused-vars
+import { Application, Context } from "probot";
 import { parseMarkdownToRules } from "./parser";
+
+const autoCommands = [
+  {
+    ruleName: "added_label",
+    webhookName: "issues.labeled",
+    ruleMatcher: (context: Context, ruleArgs: string[]): boolean => {
+      const labelName = context.payload.label.name;
+      return ruleArgs.includes(labelName);
+    },
+  },
+  {
+    ruleName: "added_label",
+    webhookName: "pull_request.labeled",
+    ruleMatcher: (context: Context, ruleArgs: string[]): boolean => {
+      const labelName = context.payload.label.name;
+      return ruleArgs.includes(labelName);
+    },
+  },
+];
 
 const PROJECT_FRAGMENT = `
   name

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,35 @@
-// import marked from "marked";
+import marked from "marked";
 
-export const parseMarkdown = (note: string): any => {
-  return note;
+export const parseMarkdown = (
+  note: string
+): { ruleName: string; ruleArgs: string[] }[] => {
+  const rules: { ruleName: string; ruleArgs: string[] }[] = [];
+  // FIXME: Update src/@types/marked/index.d.ts & Do not use any type
+  const tokens: any = marked.lexer(note);
+  const listToken = tokens.find((token: any) => token.type === "list");
+
+  listToken.items.forEach((listItem: any) => {
+    const rule: { ruleName: string; ruleArgs: string[] } = {
+      ruleName: "",
+      ruleArgs: [],
+    };
+    // 何故か type 'text' が途中に挟まってるので、チェーンして呼び出ししてる
+    // @example textTokens
+    // [
+    //   { type: "codespan", raw: "`added_label`", text: "added_label" },
+    //   { type: "text", raw: " ", text: " " },
+    //   { type: "strong", raw: "**wontfix**", text: "wontfix", },
+    // ];
+    const textTokens = listItem.tokens[0].tokens;
+    textTokens.forEach((token: any) => {
+      if (token.type === "codespan") {
+        rule.ruleName = token.text;
+      } else if (token.type === "strong") {
+        rule.ruleArgs.push(token.text);
+      }
+    });
+    rules.push(rule);
+  });
+
+  return rules;
 };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,5 @@
+// import marked from "marked";
+
+export const parseMarkdown = (note: string): any => {
+  return note;
+};

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,6 @@
 import marked from "marked";
 
-export const parseMarkdown = (
+export const parseMarkdownToRules = (
   note: string
 ): { ruleName: string; ruleArgs: string[] }[] => {
   const rules: { ruleName: string; ruleArgs: string[] }[] = [];

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -7,11 +7,25 @@ describe("parseMarkdown", () => {
     "<!-- Documentation: https://github.com/philschatz/project-bot -->\r\n" +
     "\r\n" +
     "- `added_label` **wontfix**\r\n" +
-    "- `new_pullrequest` **repo1** **repo2**";
+    "- `new_pullrequest` **repo1** **repo2**\r\n" +
+    "- `new_issue`";
 
-  const results: any = note;
+  const results: { ruleName: string; ruleArgs: string[] }[] = [
+    {
+      ruleName: "added_label",
+      ruleArgs: ["wontfix"],
+    },
+    {
+      ruleName: "new_pullrequest",
+      ruleArgs: ["repo1", "repo2"],
+    },
+    {
+      ruleName: "new_issue",
+      ruleArgs: [],
+    },
+  ];
 
-  it("parses markdown", () => {
+  it("parses markdown to rules", () => {
     expect(parseMarkdown(note)).toEqual(results);
   });
 });

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,0 +1,17 @@
+import { parseMarkdown } from "../src/parser";
+
+describe("parseMarkdown", () => {
+  const note: string =
+    "###### Automation Rules\r\n" +
+    "\r\n" +
+    "<!-- Documentation: https://github.com/philschatz/project-bot -->\r\n" +
+    "\r\n" +
+    "- `added_label` **wontfix**\r\n" +
+    "- `new_pullrequest` **repo1** **repo2**";
+
+  const results: any = note;
+
+  it("parses markdown", () => {
+    expect(parseMarkdown(note)).toEqual(results);
+  });
+});

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,6 +1,6 @@
-import { parseMarkdown } from "../src/parser";
+import { parseMarkdownToRules } from "../src/parser";
 
-describe("parseMarkdown", () => {
+describe("parseMarkdownToRules", () => {
   const note: string =
     "###### Automation Rules\r\n" +
     "\r\n" +
@@ -26,6 +26,6 @@ describe("parseMarkdown", () => {
   ];
 
   it("parses markdown to rules", () => {
-    expect(parseMarkdown(note)).toEqual(results);
+    expect(parseMarkdownToRules(note)).toEqual(results);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,8 +43,11 @@
 
     /* Module Resolution Options */
     "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    // "baseUrl": "./src" /* Base directory to resolve non-absolute module names. */,
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // workaround for @type/marked
+    "baseUrl": "./src" /* Base directory to resolve non-absolute module names. */,
+    "paths": {
+      "marked": ["@types/marked/index.d.ts"]
+    } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */


### PR DESCRIPTION
## Overview

see. #1
rel. #3

Automation Rules カードをパースして、Webhook イベント発生時にルールに沿ってカードを追加できるようにした。

## Note

### unified + remark-parse でやるパターン

ref. https://stackoverflow.com/a/53157030

迷ったけど remark-parse の依存多いし、2つもパッケージ install するの嫌だったので marked にした。

<details>
<summary>コード例</summary>

```js
const unified = require('unified');
const markdown = require('remark-parse');

const note = '###### Automation Rules\r\n' +
      '\r\n' +
      '<!-- Documentation: https://github.com/philschatz/project-bot -->\r\n' +
      '\r\n' +
      '- `added_label` **wontfix**\r\n' +
      '- `new_pullrequest` **repo1** **repo2**'
const parsed = unified().use(markdown).parse(note)

// {
//   type: 'root',
//   children: [
//     {
//       type: 'heading',
//       depth: 6,
//       children: [Array],
//       position: [Position]
//     },
//     {
//       type: 'html',
//       value: '<!-- Documentation: https://github.com/philschatz/project-bot -->',
//       position: [Position]
//     },
//     {
//       type: 'list',
//       ordered: false,
//       start: null,
//       spread: false,
//       children: [Array],
//       position: [Position]
//     }
//   ],
//   position: {
//     start: { line: 1, column: 1, offset: 0 },
//     end: { line: 6, column: 40, offset: 164 }
//   }
// }

// こんな感じで辿るイメージ
parsed.children.find(c => c.type === 'list').children[0].children[0].children
```

See. https://github.com/unifiedjs/unified#processorparsefile

</details>

## refs

- https://marked.js.org/#/USING_PRO.md#lexer

